### PR TITLE
Tame Dependabot: group updates into monthly batches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,39 +3,49 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "node"
         versions: ["27"]
+    groups:
+      monthly-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      monthly-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      monthly-batch:
+        patterns:
+          - "*"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    cooldown:
+      default-days: 7
     groups:
-      emotion:
+      monthly-minor-patch:
         patterns:
-          - "@emotion/*"
-      fortawesome:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      monthly-major:
         patterns:
-          - "@fortawesome/*"
-      mui:
-        patterns:
-          - "@mui/*"
-      next:
-        patterns:
-          - "eslint-config-next"
-          - "next"
-          - "@next/*"
-      react:
-        patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react"
-          - "@types/react-dom"
-      typescript-eslint:
-        patterns:
-          - "@typescript-eslint/*"
+          - "*"
+        update-types:
+          - "major"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,31 +90,3 @@ jobs:
           directory: out
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref_name }}
-
-  dependabot:
-    runs-on: ubuntu-latest
-    needs:
-      - upload-to-cf-pages
-    permissions:
-      contents: write
-      pull-requests: write
-    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
-    name: Automatically merge Dependabot PRs
-    steps:
-      - name: Fetch Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v3
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Enable auto-merge for Dependabot PRs (patch)
-        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr merge --auto --merge "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Enable auto-merge for Dependabot PRs (minor)
-        if: steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr merge --auto --merge "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Cuts Dependabot PR volume so every dependency update is realistically reviewable by hand, instead of relying on auto-merge to absorb the flood.

## Changes

**`.github/dependabot.yml`**
- Cadence `weekly` → `monthly` for all three ecosystems (`npm`, `docker`, `github-actions`).
- Replaced the six per-library npm groups (emotion, fortawesome, mui, next, react, typescript-eslint) with `monthly-minor-patch` and `monthly-major` groups, so a breaking major never rides along in the same PR as routine bumps. Same split for `docker`.
- `github-actions` uses a single `monthly-batch` group covering everything, majors included — action majors are rarely breaking in practice, so splitting them isn't worth the extra PR.
- Added `cooldown: default-days: 7` so versions published in the last week are skipped, giving bad releases time to be yanked or patched.
- Kept the existing `ignore` for Docker `node` v27.

**`.github/workflows/ci.yml`**
- Removed the `dependabot` job (`dependabot/fetch-metadata` + two `gh pr merge --auto` steps).

## Security updates are unaffected

None of the groups set `applies-to`, so they default to `version-updates` only. Security-advisory PRs stay individual and arrive immediately, without waiting for the monthly run or the cooldown window.

## Permissions

The removed job carried `contents: write` and `pull-requests: write`. Both grants are gone with it, so a compromised action in this workflow can no longer push to the repo or manipulate PRs. Top-level `permissions:` is unchanged (`contents: read`, `packages: write`) — `packages: write` is only needed by `build-docker-images`, which already declares it at job level, so it could be dropped from the top-level block separately.

## Follow-up outside the repo

- Repository auto-merge (Settings → General → "Allow auto-merge") may still be enabled, and PRs already queued with auto-merge will still merge.
- After merge, GitHub validates `dependabot.yml` server-side — check Insights → Dependency graph → Dependabot for a config-error banner, and use "Check for updates" there to force a grouped run rather than waiting for the month to roll over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)