### PR TITLE
Upgrade Node.js to v26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [25.x]
+        node-version: [26.x]
     name: Build and test the application
     steps:
       - uses: actions/checkout@v7
@@ -26,7 +26,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm test
-      - if: ${{ matrix.node-version == '25.x' }}
+      - if: ${{ matrix.node-version == '26.x' }}
         uses: actions/upload-artifact@v7
         with:
           name: portfolio

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:25 AS build
+FROM node:26 AS build
 
 COPY package.json package-lock.json /app/
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@next/bundle-analyzer": "^16.3.0",
         "@next/eslint-plugin-next": "^16.3.0",
         "@stylistic/eslint-plugin-ts": "^4.4.1",
-        "@types/node": "^25.9.1",
+        "@types/node": "^26.2.0",
         "@types/react": "^19.2.18",
         "@types/react-dom": "19.2.4",
         "@typescript-eslint/eslint-plugin": "^8.66.0",
@@ -1988,13 +1988,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/parse-json": {
@@ -7917,9 +7917,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@next/bundle-analyzer": "^16.3.0",
     "@next/eslint-plugin-next": "^16.3.0",
     "@stylistic/eslint-plugin-ts": "^4.4.1",
-    "@types/node": "^25.9.1",
+    "@types/node": "^26.2.0",
     "@types/react": "^19.2.18",
     "@types/react-dom": "19.2.4",
     "@typescript-eslint/eslint-plugin": "^8.66.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
       "es2017"
     ],
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noEmit": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
Node.js 25 reached end-of-life on 2026-06-01, so CI and the `ghcr.io/ymyzk/portfolio` build stage were running an unsupported runtime. This moves both to Node.js 26, which becomes LTS on 2026-10-28 and is supported until 2029-04-30.

## Changes

- `Dockerfile`: `node:25` → `node:26`
- `.github/workflows/ci.yml`: matrix `[25.x]` → `[26.x]`, plus the duplicated `'25.x'` literal in the `upload-artifact` guard (if that one is missed, the artifact upload silently skips and the Cloudflare Pages deploy breaks while `build-app` still looks green)
- `package.json` / `package-lock.json`: `@types/node` `^25.9.1` → `^26.2.0`
- `.github/dependabot.yml` is unchanged — its `node` ignore of `["27"]` is still correct now that the image is on 26

A second commit lands the `tsconfig.json` / `next-env.d.ts` output that Next.js 16.3 rewrites on every build (`moduleResolution: node` → `bundler`, added `root-params.d.ts` reference), so the checked-in files stop drifting from what the build produces. Unrelated to the runtime bump.

## Verification

Locally on Node v26.7.0:

- `npm ci` clean; `npm run build` exported all 3 static routes to `out/`
- `npm test` — `eslint .` and `tsc` both pass, so `@types/node` 26 introduced no type errors
- `hadolint` exit 0; `docker build` succeeded on `node:26`; the exported `index.html` copied out of the image is byte-identical to the local build

Every dependency's `engines` range already admits Node 26 (`next` `>=20.9.0`, `sharp` `>=21.0.0`, `glob` `20 || >=22`, `eslint` `>=21.1.0`). The Node 26 breaking changes — `NODE_MODULE_VERSION` 147, legacy `_stream_*` removals, `module.register()` runtime deprecation — don't affect this project; `sharp`'s prebuilds are Node-API so the ABI bump is a non-issue.

## Supersedes

- `dependabot/docker/node-26` — Dockerfile-only, would have desynced the image from CI and `@types/node`. Should auto-close once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)