### PR TITLE
Hold ESLint on v9 in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,11 @@ updates:
       interval: "monthly"
     cooldown:
       default-days: 7
+    # eslint-config-next and its bundled plugins (eslint-plugin-react / import / jsx-a11y)
+    # do not support ESLint v10 yet: https://github.com/vercel/next.js/issues/89764
+    ignore:
+      - dependency-name: "eslint"
+        versions: ["10.x"]
     groups:
       monthly-minor-patch:
         patterns:


### PR DESCRIPTION
The ask was to upgrade ESLint to v10 (10.8.1 is out; this repo is on `^9.39.2`). That is not possible yet, so instead this tells Dependabot not to keep offering it.

`eslint-config-next@16.3.1` cannot run on ESLint 10:

- **Peer ranges.** It depends on `eslint-plugin-import@2.32.0`, `eslint-plugin-react@7.37.5` and `eslint-plugin-jsx-a11y@6.10.2`, which all cap their `eslint` peer at `^9`, so `npm ci` fails to resolve.
- **Removed APIs at runtime** (https://github.com/vercel/next.js/issues/89764):
  - `eslint-plugin-react` calls the removed `context.getFilename()` when `settings.react.version` is `"detect"`, which is what `eslint-config-next` sets.
  - ESLint 10 calls `scopeManager.addGlobals()` for any config declaring `languageOptions.globals` under a custom parser. The `eslint-config-next` base block does exactly that via Next's vendored Babel 7 `@babel/eslint-parser`, which has no `addGlobals`. Babel has stated Babel 7 will not support ESLint 10, so this waits on Next vendoring Babel 8. That block matches `**/*.{js,jsx,mjs,ts,tsx,mts,cts}`, so here it would hit `eslint.config.mjs` and `bin/minify-images.mjs` (`.ts`/`.tsx` get re-parsed by typescript-eslint, which does implement `addGlobals`).
- Upstream `eslint-plugin-react` declines v10 usage until its peer range is updated: https://github.com/jsx-eslint/eslint-plugin-react/issues/3977

## Change

One `ignore` block on the npm ecosystem entry in `.github/dependabot.yml`, placed to match the key order of the existing docker `node` ignore.

It is scoped to the `10.x` line rather than to `version-update:semver-major`, so a future v11 is still proposed, and 9.x minor/patch bumps keep flowing through the `monthly-minor-patch` group.

Remove the entry and do the real upgrade once vercel/next.js#89764 and jsx-eslint/eslint-plugin-react#3977 are resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)